### PR TITLE
Allow xterm-keys

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -29,6 +29,9 @@ bind j select-pane -D
 bind k select-pane -U
 bind l select-pane -R
 
+# vim movements
+set -g xterm-keys on
+
 # Cycle between windows
 bind -r C-h select-window -t :-
 bind -r C-l select-window -t :+


### PR DESCRIPTION
Allows to use control + arrow to move through full words.